### PR TITLE
use #/usr/bin/env

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A docker image for building and running the StarCraft II API on Linux
 This is a work in progress. Contributions welcome!
 
 TODO:
-    * Get unit tests working on s2client-game container
-    * Automate the replay & Battle.net Cache population
-    * Create a combined container for developers (with git, API and game)
-    * Get some compose / swarm examples for doing larger training exercises
+  * [ ] Get unit tests working on s2client-game container
+  * [ ] Automate the replay & Battle.net Cache population
+  * [ ] Create a combined container for developers (with git, API and game)
+  * [ ] Get some compose / swarm examples for doing larger training exercises
 
 # Summary
 

--- a/build/all.sh
+++ b/build/all.sh
@@ -1,2 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 ./clone.sh && ./make-container.sh

--- a/build/api-build.sh
+++ b/build/api-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is intended to be embedded in the build container for
 # automating the CMake / GNU make build process

--- a/build/clone.sh
+++ b/build/clone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This clones a clean copy of the repo
 mkdir -p downloads

--- a/build/make-container.sh
+++ b/build/make-container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This builds the container
 docker build . -t s2client-api

--- a/docker_cleanup.sh
+++ b/docker_cleanup.sh
@@ -1,2 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 docker rm $(docker ps -qaf status=exited)

--- a/game/all.sh
+++ b/game/all.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./download.sh && ./unpack.sh && make-container.sh
+./download.sh && ./unpack.sh && ./make-container.sh

--- a/game/all.sh
+++ b/game/all.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./download.sh && ./unpack.sh && make-container.sh

--- a/game/download.sh
+++ b/game/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERSION=3.16.1
 

--- a/game/make-container.sh
+++ b/game/make-container.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This builds the game container
 docker build . -t s2client-game

--- a/game/unpack.sh
+++ b/game/unpack.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This unpacks all of the zip files automatically
 

--- a/replays/add_replays.sh
+++ b/replays/add_replays.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # This script downloads the replay pack, adds it to a running container


### PR DESCRIPTION
There was no /bin/bash on my system (NixOS).

[env](https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html) should make script more portable.