### PR TITLE
Script cleanup

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -29,4 +29,4 @@ WORKDIR /s2client-api
 ADD downloads/s2client-api .
 ADD api-*.sh /s2client-api/
 
-ENTRYPOINT [ "/bin/bash" ] 
+ENTRYPOINT [ "/bin/bash" ]

--- a/build/api-all.sh
+++ b/build/api-all.sh
@@ -1,2 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 ./api-build.sh && ./api-package.sh && ./api-copy.sh

--- a/build/api-copy.sh
+++ b/build/api-copy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "Copying built artifacts into /build-mount"
 ls /s2client-api/s2client-api-*
 cp /s2client-api/s2client-api-* /build-mount/

--- a/build/api-package.sh
+++ b/build/api-package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 VERSION=3.16.1
 PACKAGE=s2client-api-${VERSION}.tgz
 

--- a/build/build-copy.sh
+++ b/build/build-copy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERSION=3.16.1
 

--- a/build/make-container.sh
+++ b/build/make-container.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 
 # This builds the container
-docker build . -t s2client-api
+IMGNAME=s2client-api
+SCRIPT_PATH=${0%/*}
+
+echo ${IMGNAME} docker image building using ${SCRIPT_PATH}/Dockerfile
+docker build ${SCRIPT_PATH} -t ${IMGNAME}

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -27,4 +27,4 @@ RUN \
 # Add the code
 WORKDIR /s2client-api
 
-ENTRYPOINT [ "/bin/bash" ] 
+ENTRYPOINT [ "/bin/bash" ]

--- a/dev/make-container.sh
+++ b/dev/make-container.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 
 # This builds the container
-docker build . -t s2client-dev
+IMGNAME=s2client-dev
+SCRIPT_PATH=${0%/*}
+
+echo ${IMGNAME} docker image building using ${SCRIPT_PATH}/Dockerfile
+docker build ${SCRIPT_PATH} -t ${IMGNAME}

--- a/game/Dockerfile
+++ b/game/Dockerfile
@@ -25,4 +25,4 @@ ENTRYPOINT [ "/SC2/3.16.1/StarCraftII/Versions/Base55958/SC2_x64", \
     "-listen", \
     "127.0.0.1", \
     "-port", \
-    "12000" ] 
+    "12000" ]

--- a/game/download.sh
+++ b/game/download.sh
@@ -5,9 +5,9 @@ VERSION=3.16.1
 # This downloads zip files for current version 
 mkdir -p downloads/
 pushd downloads
-wget http://blzdistsc2-a.akamaihd.net/Linux/SC2.${VERSION}.zip
-wget http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2017Season1.zip
-wget http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2017Season2.zip
-wget http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2017Season3.zip
-wget http://blzdistsc2-a.akamaihd.net/MapPacks/Melee.zip
+wget -c http://blzdistsc2-a.akamaihd.net/Linux/SC2.${VERSION}.zip
+wget -c http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2017Season1.zip
+wget -c http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2017Season2.zip
+wget -c http://blzdistsc2-a.akamaihd.net/MapPacks/Ladder2017Season3.zip
+wget -c http://blzdistsc2-a.akamaihd.net/MapPacks/Melee.zip
 popd

--- a/game/download.sh
+++ b/game/download.sh
@@ -2,7 +2,7 @@
 
 VERSION=3.16.1
 
-# This downloads zip files for current version 
+# This downloads zip files for current version
 mkdir -p downloads/
 pushd downloads
 wget -c http://blzdistsc2-a.akamaihd.net/Linux/SC2.${VERSION}.zip

--- a/game/make-container.sh
+++ b/game/make-container.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 
-# This builds the game container
-docker build . -t s2client-game
+# This builds the container
+IMGNAME=s2client-game
+SCRIPT_PATH=${0%/*}
+
+echo ${IMGNAME} docker image building using ${SCRIPT_PATH}/Dockerfile
+docker build ${SCRIPT_PATH} -t ${IMGNAME}

--- a/game/run-interactive.sh
+++ b/game/run-interactive.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run an interactive container with the build-mount (see build/all.sh)
 docker run --entrypoint="/bin/bash" -v build-mount:/build-mount -it s2client-game

--- a/game/run-tests.sh
+++ b/game/run-tests.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Run an interactive container with the build-mount (see build/all.sh)
 docker run -v build-mount:/build-mount -t --entrypoint="/build-mount/all_tests -e /SC2/3.16.1/StarCraftII/Versions/Base55958/SC2_x64" s2client-game

--- a/replays/add-replays.sh
+++ b/replays/add-replays.sh
@@ -11,9 +11,10 @@ VERSION=3.16.1
 #
 REPLAY_PACK=3.16.1-Pack_1-fix.zip
 
+mkdir -p downloads
 if [ ! -f downloads/${REPLAY_PACK} ]; then
     pushd downloads
-    wget http://blzdistsc2-a.akamaihd.net/ReplayPacks/${REPLAY_PACK}
+    wget -c http://blzdistsc2-a.akamaihd.net/ReplayPacks/${REPLAY_PACK}
     mkdir -p replays
     unzip -Piagreetotheeula ${REPLAY_PACK} -d replays/
     popd


### PR DESCRIPTION
Just some few more cleanup.

I make `make-container.sh` callable without having to `cd` in to the directory it contains so I can do things like this

    $ find . | grep make\-container\.sh | xargs -i sh {}